### PR TITLE
Remove postinstall from NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "main": "./lib/atem.js",
   "scripts": {
     "test": "mocha test",
-    "build": "coffee -bc ./lib/atem.coffee",
-    "postinstall": "build"
+    "build": "coffee -bc ./lib/atem.coffee"
   },
   "dependencies": {
     "async": "^1.3.0",


### PR DESCRIPTION
The built version is deployed to npm so this is not required on the client side.

This should also fix https://github.com/applest/node-applest-atem/issues/19