### PR TITLE
Get macro details

### DIFF
--- a/src/atem.coffee
+++ b/src/atem.coffee
@@ -90,6 +90,8 @@ class ATEM
       hasMonitor: null
       numberOfChannels: null
       channels: {}
+    macros: {}
+    macro_banks: null
 
   connectionState: ATEM.ConnectionState.Closed
   localPackedId: 1
@@ -239,6 +241,19 @@ class ATEM
       when '_MeC'
         me = buffer[0]
         @state.video.ME[me].numberOfKeyers = buffer[1]
+
+      when '_MAC'
+        @state.macro_banks = buffer[1]
+
+      when 'MPrp'
+        isUsed = buffer[2]
+        if isUsed # Only keep info on macros that are present
+          nameLength = buffer[5]
+          descriptionLength = buffer[7]
+          @state.macros[buffer[1]] =
+            isUsed: buffer[2]
+            name: @_parseString(buffer[8...nameLength+8])
+            description: @_parseString(buffer[8+nameLength...8+nameLength+descriptionLength])
 
       when 'InPr'
         channel = @_parseNumber(buffer[0..1])

--- a/test/test-atem.coffee
+++ b/test/test-atem.coffee
@@ -70,7 +70,7 @@ describe 'Atem', ->
       sw.changeAuxInput(0, 1)
       sw.changeAuxInput(1, 1)
       sw.changeAuxInput(2, 1)
-      setTimeout(done, 100)
+      setTimeout(done, 1000)
 
     it 'expects change all camera input', (done) ->
       auxs =  Object.keys(sw.state.video.auxs)
@@ -88,7 +88,7 @@ describe 'Atem', ->
     before (done) ->
       for me in [0...sw.state.topology.numberOfMEs]
         sw.fadeToBlack(me) if sw.state.video.ME[me].fadeToBlack
-      setTimeout(done, 1500)
+      setTimeout(done, 2000)
 
     it 'expects fade to black', (done) ->
       async.eachSeries([0...sw.state.topology.numberOfMEs], (me, nextME) ->
@@ -199,7 +199,7 @@ describe 'Atem', ->
     before (done) ->
       for me in [0...sw.state.topology.numberOfMEs]
         sw.changeTransitionType(ATEM.TransitionStyle.DIP, me)
-      setTimeout(done, 100)
+      setTimeout(done, 1000)
 
     it 'expects change all transition type', (done) ->
       types = if sw.state.model == ATEM.Model.TVS || sw.state.model == ATEM.Model.PS4K
@@ -394,6 +394,7 @@ describe 'Atem', ->
         sw.changeAudioChannelState(channel, false)
         next null, null
       , done)
+      # setTimeout(done, 100)
 
     before initialize
 
@@ -438,7 +439,7 @@ describe 'Atem', ->
   describe 'runMacro', ->
     before (done) ->
       sw.changeProgramInput(1)
-      setTimeout(done, 100)
+      setTimeout(done, 1000)
 
     it 'expects run macro', (done) ->
       sw.startRecordMacro(99, 'Test Macro', 'Hey! This is macro.')
@@ -456,7 +457,7 @@ describe 'Atem', ->
     after (done) ->
       sw.deleteMacro(99)
       sw.changeProgramInput(1)
-      setTimeout(done, 100)
+      setTimeout(done, 1000)
 
   after ->
     console.log """\n-------- ATEM Information --------

--- a/test/test-atem.coffee
+++ b/test/test-atem.coffee
@@ -444,6 +444,8 @@ describe 'Atem', ->
       sw.startRecordMacro(99, 'Test Macro', 'Hey! This is macro.')
       sw.changeProgramInput(2)
       sw.stopRecordMacro()
+      expect(sw.state.macro[99].name).be.eq('Test Macro')
+      expect(sw.state.macro[99].description).be.eq('Hey! This is macro.')
       sw.changeProgramInput(1)
       sw.runMacro(99)
       setTimeout( ->


### PR DESCRIPTION
Add support for getting macro details from Atem.

I only have an Atem Mini, so I think some of the tests are failing for features that the other Atems have. Some of the test failures seem to be timing related also as they sometimes pass fine.